### PR TITLE
Adiciona models de User e Marketplace certo

### DIFF
--- a/feira_da_lua/marketplace/models.py
+++ b/feira_da_lua/marketplace/models.py
@@ -1,3 +1,20 @@
 from django.db import models
+from django.conf import settings
 
-# Create your models here.
+
+class MarketPlace(models.Model):
+    name = models.CharField(max_length=255)
+    marketer = models.ForeignKey(
+        "marketers.Marketer",     # Marketer ainda não existe, mas Django aceita referência por string
+        on_delete=models.CASCADE,
+        related_name="marketplaces"
+    )
+    address = models.CharField(max_length=255)
+    coordinates = models.CharField(max_length=255)
+
+    # Imaginei que poderia ser campos nulos que poderiam ser atualizados dinamicamente
+    average_grade = models.FloatField(null=True, blank=True)
+    average_price = models.FloatField(null=True, blank=True)
+
+    def __str__(self):
+        return self.name

--- a/feira_da_lua/users/models.py
+++ b/feira_da_lua/users/models.py
@@ -1,3 +1,12 @@
+from django.contrib.auth.models import AbstractUser
 from django.db import models
 
-# Create your models here.
+class User(AbstractUser):
+    complete_name = models.CharField(max_length=255)
+
+    # Campos padrões do AbstractUser já incluem:
+    # username, email, password, first_name, last_name, etc.
+    # Você pode remover first_name e last_name no settings se quiser.
+
+    def __str__(self):
+        return self.username


### PR DESCRIPTION
1 - No marketplace imaginei que average_grade e average_price poderiam ser nulos, pq quando criados n teriam nenhuma avaliação

2 - Já existe um user padrão no django e ele já tem a maioria dos campos, só extendi e coloquei o campo complete_name. Poderia ter criado um do zero, mas n fiz

3 - No doc das especificações estava escrito:

avarange_grade
avarange_price

Eu supus que só foi um errinho de escrita e era para ser "average" ent coloquei assim.

4 - Aparentemente no Django tem id automático. Dexei assim no MarketPlace